### PR TITLE
Change where entity's id is stored when no friendly name is found

### DIFF
--- a/main.py
+++ b/main.py
@@ -115,7 +115,7 @@ class KeywordQueryEventListener(EventListener):
                 continue
 
             if "friendly_name" not in entity["attributes"]:
-                entity["friendly_name"] = entity["entity_id"]
+                entity["attributes"]["friendly_name"] = entity["entity_id"]
 
             # Don't add this item if the query doesn't appear in either friendly_name or id
             entity_appears_in_search = True


### PR DESCRIPTION
The location where the id of an entity is stored when no friendly name is found was not aligned with the check being done [at line 125](https://github.com/qcasey/ulauncher-homeassistant/blob/521c7790700957b819f104862545d97121a904cc/main.py#L125). This can occasionaly cause errors:

```
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/ulauncher/api/client/Client.py", line 54, in on_message
    self.extension.trigger_event(event)
  File "/usr/lib/python3.9/site-packages/ulauncher/api/client/Extension.py", line 52, in trigger_event
    action = listener.on_event(event, self)
  File "/home/.../ulauncher-homeassistant/main.py", line 125, in on_event
    not in entity["attributes"]["friendly_name"].lower()
KeyError: 'friendly_name'
```

This error is only visible in logs and the user would not normally see it. This PR fixes the problem.