### PR TITLE
Change empty event argument handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,7 +33,7 @@ class HomeAssistantExtension(Extension):
 class KeywordQueryEventListener(EventListener):
     def on_event(self, event, extension):
         items = []
-        query = event.get_argument().lower() or str()
+        query = (event.get_argument() or str()).lower()
 
         hass_url = extension.preferences["hass_url"]
         if not hass_url:


### PR DESCRIPTION
When `event` has no arguments, the `get_argument()` returns `None`, causing the call to `.lower()` to raise an exception.

```
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/ulauncher/api/client/Client.py", line 54, in on_message
    self.extension.trigger_event(event)
  File "/usr/lib/python3.9/site-packages/ulauncher/api/client/Extension.py", line 52, in trigger_event
    action = listener.on_event(event, self)
  File "/home/.../ulauncher-homeassistant/main.py", line 36, in on_event
    query = event.get_argument().lower() or str()
AttributeError: 'NoneType' object has no attribute 'lower'

```

This PR changes the order of the operations so that this doesn't happen.